### PR TITLE
Handle circular references when serializing node content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-kentico-cloud",
   "description": "Gatsby source plugin for Kentico Cloud",
-  "version": "2.0.0-beta1",
+  "version": "2.0.0-beta2",
   "repository": {
     "type": "git",
     "url": "https://github.com/Kentico/gatsby-source-kentico-cloud"

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -242,7 +242,24 @@ of valid objects.`);
 const createKcArtifactNode =
   (nodeId, kcArtifact, artifactKind, typeName = ``,
       additionalNodeData = null) => {
-    const nodeContent = JSON.stringify(kcArtifact);
+    let processedProperties = [];
+
+    // Handle circular references when serializing.
+    const nodeContent = JSON.stringify(kcArtifact, (key, value) =>{
+      if (typeof value === `object` && value !== null) {
+        if (processedProperties.indexOf(value) !== -1) {
+          try {
+            return JSON.parse(JSON.stringify(value));
+          } catch (error) {
+            return;
+          }
+        }
+        processedProperties.push(value);
+      }
+      return value;
+    });
+
+    processedProperties = null;
 
     const nodeContentDigest = crypto
         .createHash(`md5`)


### PR DESCRIPTION
### Motivation

Handles circular references to linked content items when serializing the node content.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults
