### PR TITLE
Get around GraphQL naming limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ All nodes have a `usedByContentItems` property that reflects the other nodes in 
 
 ## Troubleshooting
 
-Gatsby's GraphQL libraries won't accept object properties with names starting with numbers. This conflicts with the way image assets are named in the Delivery API response (in the JS SDK output, respectively). Therefore, the names of assets are prefixed by the source plugin with `image-`.
+Gatsby's GraphQL libraries won't accept object properties with names starting with numbers. This conflicts with the way image assets and links are named in the Delivery API response (in the JS SDK output, respectively). Therefore, the names of properties with assets and links in Rich text are prefixed by the source plugin with `image-` and `link-` respectively.
 
     "images": {
       "image-79bd9e11-f643-4cd6-9ea5-d1be17cf7de2": {
@@ -168,7 +168,7 @@ Gatsby's GraphQL libraries won't accept object properties with names starting wi
         "url": "https://assets-eu-01.kc-usercontent.com:443/5ac93d1e-567d-01e6-e3b7-ac435f77b907/36cb3d1b-1aa7-4809-9606-82c3c0f00b7f/fcyTulxr.jpg"
       }
 
-Should you need to refer to the properties, just bear in mind the addition of the `image-` suffix. The GUID in the child `image_id` property is never prefixed or otherwise transformed.
+Should you need to refer to the properties, just bear in mind the addition of the `image-` and `link-` prefix. In case of images, the GUID in the child `image_id` property is never prefixed or otherwise transformed.
 
 ## Further information
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-kentico-cloud",
   "description": "Gatsby source plugin for Kentico Cloud",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Kentico/gatsby-source-kentico-cloud"


### PR DESCRIPTION
All guid-named properties are now prefixed.

### Motivation

Fixes #25 

Moreover, all guid-named properties are handled to comply with GraphQL naming limitations.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [x] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults
