### PR TITLE
use array instead of joining and splitting string

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -335,20 +335,18 @@ const prefixProperty = (propertyValue, identifier, prefixLiteral) => {
 };
 
 const parseContentItemContents =
-  (contentItem, processedContents = [], originalItem) => {
+  (contentItem, processedContents = [[]]) => {
     for (let path of processedContents) {
-      const items = path.split(';');
-      if (items.includes(contentItem.codename)) {
+      if (path.includes(contentItem.system.codename)) {
         throw Error(`Cycle detected in linked items' path: ${path}`);
-      };
+      }
     }
 
     const lastPath = processedContents[processedContents.length - 1];
-    const currentItemPath = originalItem
-    ? lastPath + ';' + contentItem.system.codename
-    : contentItem.system.codename;
+    const currentItemPathClone = lastPath.slice();
+    currentItemPathClone.push(contentItem.system.codename);
 
-    processedContents.push(currentItemPath);
+    processedContents.push(currentItemPathClone);
     const elements = {};
 
     Object
@@ -374,9 +372,7 @@ const parseContentItemContents =
 
             contentItem[key].forEach((linkedItem) => {
               linkedItems.push(
-                  parseContentItemContents(
-                      linkedItem, processedContents, contentItem
-                  )
+                  parseContentItemContents(linkedItem, processedContents)
               );
             });
 

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -335,18 +335,12 @@ const prefixProperty = (propertyValue, identifier, prefixLiteral) => {
 };
 
 const parseContentItemContents =
-  (contentItem, processedContents = [[]]) => {
-    for (let path of processedContents) {
-      if (path.includes(contentItem.system.codename)) {
-        throw Error(`Cycle detected in linked items' path: ${path}`);
-      }
+  (contentItem, processedContents = []) => {
+    if (processedContents.includes(contentItem.system.codename)) {
+      throw Error(`Cycle detected in linked items' path: ${path}`);
     }
+    processedContents.push(contentItem.system.codename);
 
-    const lastPath = processedContents[processedContents.length - 1];
-    const currentItemPathClone = lastPath.slice();
-    currentItemPathClone.push(contentItem.system.codename);
-
-    processedContents.push(currentItemPathClone);
     const elements = {};
 
     Object


### PR DESCRIPTION
### Motivation

Fixes #36 

@JanLenoch 
* are your really sure that is not required to store the history of branching?

I have split the enhancement into two parts:
* use array instead of string splitting and joining
* remove storing history

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docu has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

Run tests - extend tests with more complex structure to test