### PR TITLE
Typo in Property name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-kentico-cloud",
-  "version": "2.1.4-beta",
+  "version": "2.1.4-beta2",
   "description": "Gatsby source plugin for Kentico Cloud",
   "main": "./gatsby-node.js",
   "scripts": {

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -405,7 +405,7 @@ const addLinkedItemsLinks =
       });
     }
 
-    itemNode.element[linkPropertyName] = sortArrayByAnotherOne(
+    itemNode.elements[linkPropertyName] = sortArrayByAnotherOne(
       itemNode.elements[linkPropertyName],
       idsOfOriginalNodes
     );


### PR DESCRIPTION
### Motivation

#35 introduced one typo which leads to missing (linked items)[https://github.com/Kentico/gatsby-source-kentico-cloud#linked-items-elements-relationships] properties

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docu has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults