### PR TITLE
Extract tracking header definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 # Output files
 /gatsby-node.js
 /normalize.js
+/config.js

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@
 # Recursively allow files under subtree¨
 !gatsby-node.js
 !normalize.js
+!config.js
 !package.json
 !.npmignore
 !README.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-kentico-cloud",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Gatsby source plugin for Kentico Cloud",
   "main": "./gatsby-node.js",
   "scripts": {

--- a/src/__tests__/gatsby-node.spec.js
+++ b/src/__tests__/gatsby-node.spec.js
@@ -1,6 +1,7 @@
 const { TestHttpService } = require('kentico-cloud-core');
 
-const { customTrackingHeader, sourceNodes } = require('../gatsby-node');
+const { sourceNodes } = require('../gatsby-node');
+const { customTrackingHeader } = require('../config');
 const { name, version } = require('../../package.json');
 
 describe('customTrackingHeader', () => {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,6 @@
+const customTrackingHeader = {
+  header: 'X-KC-SOURCE',
+  value: 'gatsby-source-kentico-cloud;2.2.1',
+};
+
+exports.customTrackingHeader = customTrackingHeader;

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -3,13 +3,10 @@ const _ = require(`lodash`);
 const { DeliveryClient } = require(`kentico-cloud-delivery`);
 const normalize = require(`./normalize`);
 const { parse, stringify } = require(`flatted/cjs`);
+const { customTrackingHeader } = require('./config')
+
 const defaultLanguageLiteral = `default`;
 
-const customTrackingHeader = {
-  header: 'X-KC-SOURCE',
-  value: 'gatsby-source-kentico-cloud;2.2.0',
-};
-exports.customTrackingHeader = customTrackingHeader;
 
 exports.sourceNodes =
   async ({ actions: { createNode }, createNodeId },


### PR DESCRIPTION
### Motivation

When the header is exported in `gatsby-node.js` error is raised when building the site:
```
Your plugins must export known APIs from their gatsby-node.js.
The following exports aren't APIs. Perhaps you made a typo or your plugin is outdated?

See https://www.gatsbyjs.org/docs/node-apis/ for the list of Gatsby Node APIs

- The plugin "gatsby-source-kentico-cloud@2.2.0" is exporting a variable named "customTrackingHeader" which isn't an API.
```

### How to test

Use the plugin on site and run `gatsby develop` or `gatsby build`