### PR TITLE
Add custom header in correct format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-kentico-cloud",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Gatsby source plugin for Kentico Cloud",
   "main": "./gatsby-node.js",
   "scripts": {

--- a/src/__tests__/gatsby-node.spec.js
+++ b/src/__tests__/gatsby-node.spec.js
@@ -54,7 +54,7 @@ describe('sourceNodes', () => {
       }
     );
 
-    expect(deliveryClientConfig.customHeaders)
+    expect(deliveryClientConfig.globalHeaders)
       .toContainEqual(customTrackingHeader);
   });
 
@@ -62,7 +62,7 @@ describe('sourceNodes', () => {
     const deliveryClientConfig = {
       projectId: 'dummyEmptyProject',
       httpService: fakeEmptyTestService,
-      customHeaders: [
+      globalHeaders: [
         {
           header: customTrackingHeader.header,
           value: 'dummyValue',
@@ -83,9 +83,9 @@ describe('sourceNodes', () => {
       }
     );
 
-    expect(deliveryClientConfig.customHeaders)
+    expect(deliveryClientConfig.globalHeaders)
       .toContainEqual(customTrackingHeader);
-    expect(deliveryClientConfig.customHeaders.length)
+    expect(deliveryClientConfig.globalHeaders.length)
       .toEqual(1);
   });
 
@@ -97,7 +97,7 @@ describe('sourceNodes', () => {
     const deliveryClientConfig = {
       projectId: 'dummyEmptyProject',
       httpService: fakeEmptyTestService,
-      customHeaders: [
+      globalHeaders: [
         anotherHeader,
       ],
     };
@@ -115,11 +115,11 @@ describe('sourceNodes', () => {
       }
     );
 
-    expect(deliveryClientConfig.customHeaders)
+    expect(deliveryClientConfig.globalHeaders)
       .toContainEqual(customTrackingHeader);
-    expect(deliveryClientConfig.customHeaders)
+    expect(deliveryClientConfig.globalHeaders)
       .toContainEqual(anotherHeader);
-    expect(deliveryClientConfig.customHeaders.length)
+    expect(deliveryClientConfig.globalHeaders.length)
       .toEqual(2);
   });
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 const customTrackingHeader = {
   header: 'X-KC-SOURCE',
-  value: 'gatsby-source-kentico-cloud;2.3.0',
+  value: 'gatsby-source-kentico-cloud;2.3.1',
 };
 
 exports.customTrackingHeader = customTrackingHeader;

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -275,8 +275,8 @@ languageVariantNode.id: ${languageVariantNode.id}`
  * @param {IHeader} trackingHeader tracking header name
  */
 const addHeader = (deliveryClientConfig, trackingHeader) => {
-  let headers = deliveryClientConfig.customHeaders
-    ? deliveryClientConfig.customHeaders.slice()
+  let headers = deliveryClientConfig.globalHeaders
+    ? deliveryClientConfig.globalHeaders.slice()
     : [];
 
   if (headers.some((header) => header.header === trackingHeader.header)) {
@@ -291,6 +291,6 @@ const addHeader = (deliveryClientConfig, trackingHeader) => {
     header: trackingHeader.header,
     value: trackingHeader.value,
   });
-  deliveryClientConfig.customHeaders = headers;
+  deliveryClientConfig.globalHeaders = headers;
 };
 


### PR DESCRIPTION
### Motivation

SDK was not sending custom tracking header, because it was setting `customHeaders`property instead of the `globalHeaders` one in [Client Configutration object](https://github.com/Kentico/kentico-cloud-js/blob/master/packages/delivery/DOCS.md#client-configuration).

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Covered by tests
