### PR TITLE
DCN-119 fix warnig for two elements with the same name in the Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-kentico-cloud",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Gatsby source plugin for Kentico Cloud",
   "main": "./gatsby-node.js",
   "scripts": {

--- a/src/__tests__/decorators/contentItemNodesWithLinkedItems.json
+++ b/src/__tests__/decorators/contentItemNodesWithLinkedItems.json
@@ -1,0 +1,106 @@
+[
+  {
+    "system": {
+      "name": "Master",
+      "codename": "master",
+      "id": "06439d5a-0ec6-4d70-b13a-7482a9e04fcc",
+      "lastModified": "2019-04-29T13:04:28.4841899Z",
+      "language": "default",
+      "type": "content_item",
+      "sitemapLocations": []
+    },
+    "elements": {
+      "sub_items": [
+        {
+          "system": {
+            "name": "Sub item 1",
+            "codename": "sub_item_1",
+            "id": "3a3fd38a-57a4-4c79-9f48-0734e5b278a4",
+            "lastModified": "2019-04-29T13:04:23.546524Z",
+            "language": "default",
+            "type": "content_item",
+            "sitemapLocations": []
+          },
+          "elements": {
+            "sub_items": []
+          }
+        },
+        {
+          "system": {
+            "name": "Sub Item 2",
+            "codename": "sub_item_2",
+            "id": "77162bf6-28a2-4c81-b9b0-a4442c2178c5",
+            "lastModified": "2019-04-29T13:04:33.247446Z",
+            "language": "default",
+            "type": "content_item",
+            "sitemapLocations": []
+          },
+          "elements": {
+            "sub_items": []
+          }
+        }
+      ]
+    },
+    "otherLanguages___NODE": [],
+    "contentType___NODE": "44a1049c-a9b3-553d-9591-0aa0d46da58e",
+    "id": "542f38b5-f09c-5739-b23b-a65c9cd43e24",
+    "parent": null,
+    "children": [],
+    "usedByContentItems___NODE": [],
+    "internal": {
+      "type": "KenticoCloudItemContentItem",
+      "content": "{\"system\":{\"name\":\"Master\",\"codename\":\"master\",\"id\":\"06439d5a-0ec6-4d70-b13a-7482a9e04fcc\",\"lastModified\":\"2019-04-29T13:04:28.4841899Z\",\"language\":\"default\",\"type\":\"content_item\",\"sitemapLocations\":[]},\"elements\":{\"sub_items\":[{\"system\":{\"name\":\"Sub item 1\",\"codename\":\"sub_item_1\",\"id\":\"3a3fd38a-57a4-4c79-9f48-0734e5b278a4\",\"lastModified\":\"2019-04-29T13:04:23.546524Z\",\"language\":\"default\",\"type\":\"content_item\",\"sitemapLocations\":[]},\"elements\":{\"sub_items\":[]}},{\"system\":{\"name\":\"Sub Item 2\",\"codename\":\"sub_item_2\",\"id\":\"77162bf6-28a2-4c81-b9b0-a4442c2178c5\",\"lastModified\":\"2019-04-29T13:04:33.247446Z\",\"language\":\"default\",\"type\":\"content_item\",\"sitemapLocations\":[]},\"elements\":{\"sub_items\":[]}}]}}",
+      "contentDigest": "e1987c918ed3d77a5150848ed635ee5c"
+    }
+  },
+  {
+    "system": {
+      "name": "Sub item 1",
+      "codename": "sub_item_1",
+      "id": "3a3fd38a-57a4-4c79-9f48-0734e5b278a4",
+      "lastModified": "2019-04-29T13:04:23.546524Z",
+      "language": "default",
+      "type": "content_item",
+      "sitemapLocations": []
+    },
+    "elements": {
+      "sub_items": []
+    },
+    "otherLanguages___NODE": [],
+    "contentType___NODE": "44a1049c-a9b3-553d-9591-0aa0d46da58e",
+    "id": "929fe570-2f9b-5a5d-8eea-ebfa4668c373",
+    "parent": null,
+    "children": [],
+    "usedByContentItems___NODE": [],
+    "internal": {
+      "type": "KenticoCloudItemContentItem",
+      "content": "{\"system\":{\"name\":\"Sub item 1\",\"codename\":\"sub_item_1\",\"id\":\"3a3fd38a-57a4-4c79-9f48-0734e5b278a4\",\"lastModified\":\"2019-04-29T13:04:23.546524Z\",\"language\":\"default\",\"type\":\"content_item\",\"sitemapLocations\":[]},\"elements\":{\"sub_items\":[]}}",
+      "contentDigest": "e66f2e9d546df4d1ac26d8b831f9b2df"
+    }
+  },
+  {
+    "system": {
+      "name": "Sub Item 2",
+      "codename": "sub_item_2",
+      "id": "77162bf6-28a2-4c81-b9b0-a4442c2178c5",
+      "lastModified": "2019-04-29T13:04:33.247446Z",
+      "language": "default",
+      "type": "content_item",
+      "sitemapLocations": []
+    },
+    "elements": {
+      "sub_items": []
+    },
+    "otherLanguages___NODE": [],
+    "contentType___NODE": "44a1049c-a9b3-553d-9591-0aa0d46da58e",
+    "id": "7f404adf-e843-5c1b-b8f5-8a4e5c4eba2a",
+    "parent": null,
+    "children": [],
+    "usedByContentItems___NODE": [],
+    "internal": {
+      "type": "KenticoCloudItemContentItem",
+      "content": "{\"system\":{\"name\":\"Sub Item 2\",\"codename\":\"sub_item_2\",\"id\":\"77162bf6-28a2-4c81-b9b0-a4442c2178c5\",\"lastModified\":\"2019-04-29T13:04:33.247446Z\",\"language\":\"default\",\"type\":\"content_item\",\"sitemapLocations\":[]},\"elements\":{\"sub_items\":[]}}",
+      "contentDigest": "51af72a0f09def109d055314469b47f1"
+    }
+  }
+]

--- a/src/__tests__/decorators/linkedItemsElementDecorator.spec.js
+++ b/src/__tests__/decorators/linkedItemsElementDecorator.spec.js
@@ -1,0 +1,23 @@
+const _ = require(`lodash`);
+
+const linkedItemsElementDecorator =
+  require('../../decorators/linkedItemsElementDecorator');
+
+const contentItemNodesWithLinkedItems =
+  require('./contentItemNodesWithLinkedItems.json');
+
+describe('decorateItemNodeWithLinkedItemsLinks', () => {
+  it(
+    'remove linked items element property and creates ___NODE ones',
+    () => {
+      const defaultCultureItems = _.cloneDeep(contentItemNodesWithLinkedItems);
+
+      linkedItemsElementDecorator
+        .decorateItemNodesWithLinkedItemsLinks(defaultCultureItems, []);
+
+      defaultCultureItems.forEach((item) =>
+        expect(item.elements).not.toHaveProperty('sub_items'));
+      defaultCultureItems.forEach((item) =>
+        expect(item.elements).toHaveProperty('sub_items___NODE'));
+    });
+});

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 const customTrackingHeader = {
   header: 'X-KC-SOURCE',
-  value: 'gatsby-source-kentico-cloud;3.0.1',
+  value: 'gatsby-source-kentico-cloud;3.0.2',
 };
 
 module.exports = {

--- a/src/decorators/linkedItemsElementDecorator.js
+++ b/src/decorators/linkedItemsElementDecorator.js
@@ -78,6 +78,8 @@ const decorateItemNodeWithLinkedItemsLinks =
               itemNode.elements[propertyName]
             );
           }
+
+          delete itemNode.elements[propertyName];
         }
       });
   };


### PR DESCRIPTION
### Motivation

When the item contained linked items elements a warning was raised during the building site (`npm run build`  `npm run develop`).

```plain
warning Multiple node fields resolve to the same GraphQL field `KenticoCloudItemStep.elements.persona` - [`persona`, `persona___NODE`]. Gatsby will use `persona___NODE`.
```

It was because of node inserted to the Gatsby plugin contained a property with name X and also X___NODE. 

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

The test was created.
