### PR TITLE
Update link tag in StackOverflow from `kentico-cloud` to `kentico-kontent`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Sorry to hear that. Just log a new [GitHub issue](../../issues) and someone will
 <img align="right" width="100" height="100" src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-icon.svg">
 
 To get help with coding and structuring your projects, use [StackOverflow](https://stackoverflow.com/) to ask questions with one of the following tags:
-- [`kentico-cloud`](https://stackoverflow.com/questions/tagged/kentico-cloud)
+- [`kentico-kontent`](https://stackoverflow.com/questions/tagged/kentico-kontent)
 - [`kentico`](https://stackoverflow.com/questions/tagged/kentico)
 
 Our team members and the community monitor these channels on a regular basis.


### PR DESCRIPTION
### Motivation

Correct the link to StackOverflow to use the [kentico-kontent][2] tag rather than the [kentico-cloud][1] tag.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [x] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Click the links through to see tagged items in [StackOverflow][3]:
- Original [kentico-cloud][1] tag
- New [kentico-kontent][2] tag

The original tag no longer has any associated questions.

[1]: https://stackoverflow.com/questions/tagged/kentico-cloud
[2]: https://stackoverflow.com/questions/tagged/kentico-kontent
[3]: https://stackoverflow.com/
